### PR TITLE
fix(translate): Expose enclosure info list as a file

### DIFF
--- a/pollination/honeybee_radiance/translate.py
+++ b/pollination/honeybee_radiance/translate.py
@@ -50,7 +50,12 @@ class CreateRadiantEnclosureInfo(Function):
             '--folder output --log-file enclosure_list.json'
 
     enclosure_list = Outputs.dict(
-        description='A JSON array that includes information about generated radiant '
+        description='A list of dictionaries that include information about generated '
+        'radiant enclosure files.', path='enclosure_list.json'
+    )
+
+    enclosure_list_file = Outputs.file(
+        description='A JSON file that includes information about generated radiant '
         'enclosure files.', path='enclosure_list.json'
     )
 


### PR DESCRIPTION
I realized that I am going to need this file in the results folder in order to know how to parse the final CSV data in the right order to be displayed in Grasshopper.