### PR TITLE
Fix sensor grids info

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-pytest==6.2.2
+pytest==6.2.3
 twine==3.4.1
 wheel==0.36.2
-setuptools==54.2.0
+setuptools==56.0.0

--- a/pollination/honeybee_radiance/translate.py
+++ b/pollination/honeybee_radiance/translate.py
@@ -63,11 +63,23 @@ class CreateRadianceFolderGrid(Function):
     model_folder = Outputs.folder(description='Radiance folder.', path='model')
 
     sensor_grids = Outputs.list(
-        description='Sensor grids information.', path='model/grid/_info.json'
+        description='Information for exported sensor grids in grids subfolder.',
+        path='model/grid/_info.json'
     )
 
     sensor_grids_file = Outputs.file(
-        description='Sensor grids information JSON file.', path='model/grid/_info.json'
+        description='Information JSON file for exported sensor grids in grids '
+        'subfolder.', path='model/grid/_info.json'
+    )
+
+    model_sensor_grids = Outputs.list(
+        description='Sensor grids information from the HB model.',
+        path='model/grid/_model_grids_info.json'
+    )
+
+    model_sensor_grids_file = Outputs.file(
+        description='Sensor grids information from the HB model JSON file.',
+        path='model/grid/_model_grids_info.json'
     )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pollination-dsl>=0.11.5
-honeybee-radiance>=1.38.3
+pollination-dsl>=0.12.1
+honeybee-radiance>=1.38.12


### PR DESCRIPTION
With this change the order of sensor grids should be exported correctly when a radiance folder is created.