### PR TITLE
fix(bsdf): Allow bsdf folders to be optional

### DIFF
--- a/pollination/honeybee_radiance/coefficient.py
+++ b/pollination/honeybee_radiance/coefficient.py
@@ -61,7 +61,7 @@ class DaylightCoefficient(Function):
 
     bsdf_folder = Inputs.folder(
         description='Folder containing any BSDF files needed for ray tracing.',
-        path='model/bsdf'
+        path='model/bsdf', optional=True
     )
 
     @command

--- a/pollination/honeybee_radiance/contrib.py
+++ b/pollination/honeybee_radiance/contrib.py
@@ -67,7 +67,7 @@ class DaylightContribution(Function):
 
     bsdf_folder = Inputs.folder(
         description='Folder containing any BSDF files needed for ray tracing.',
-        path='model/bsdf'
+        path='model/bsdf', optional=True
     )
 
     @command

--- a/pollination/honeybee_radiance/raytrace.py
+++ b/pollination/honeybee_radiance/raytrace.py
@@ -30,7 +30,7 @@ class RayTracingDaylightFactor(Function):
 
     bsdf_folder = Inputs.folder(
         description='Folder containing any BSDF files needed for ray tracing.',
-        path='model/bsdf'
+        path='model/bsdf', optional=True
     )
 
     @command
@@ -77,7 +77,7 @@ class RayTracingPointInTime(Function):
 
     bsdf_folder = Inputs.folder(
         description='Folder containing any BSDF files needed for ray tracing.',
-        path='model/bsdf'
+        path='model/bsdf', optional=True
     )
 
     @command

--- a/pollination/honeybee_radiance/rpict.py
+++ b/pollination/honeybee_radiance/rpict.py
@@ -47,7 +47,7 @@ class RayTracingPicture(Function):
 
     bsdf_folder = Inputs.folder(
         description='Folder containing any BSDF files needed for ray tracing.',
-        path='model/bsdf'
+        path='model/bsdf', optional=True
     )
 
     @command

--- a/pollination/honeybee_radiance/translate.py
+++ b/pollination/honeybee_radiance/translate.py
@@ -64,7 +64,7 @@ class CreateRadianceFolderGrid(Function):
 
     bsdf_folder = Outputs.folder(
         description='Folder containing any BSDF files needed for the simulation.',
-        path='model/bsdf'
+        path='model/bsdf', optional=True
     )
 
     sensor_grids = Outputs.list(
@@ -113,7 +113,7 @@ class CreateRadianceFolderView(Function):
 
     bsdf_folder = Outputs.folder(
         description='Folder containing any BSDF files needed for the simulation.',
-        path='model/bsdf'
+        path='model/bsdf', optional=True
     )
 
     views = Outputs.list(

--- a/pollination/honeybee_radiance/view.py
+++ b/pollination/honeybee_radiance/view.py
@@ -39,7 +39,7 @@ class SplitView(Function):
 
     bsdf_folder = Inputs.folder(
         description='Folder containing any BSDF files needed for ray tracing.',
-        path='model/bsdf'
+        path='model/bsdf', optional=True
     )
 
     @command

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pollination-dsl==0.12.3
-honeybee-radiance==1.42.14
+honeybee-radiance==1.42.15


### PR DESCRIPTION
We still use a dummy folder for now but setting all of these to be optional will make it easier in the future when queenbee-argo will support optional artifacts.