### PR TITLE
fix(annual metrics): fix the metrics_info output

### DIFF
--- a/pollination/honeybee_radiance/post_process.py
+++ b/pollination/honeybee_radiance/post_process.py
@@ -283,8 +283,9 @@ class AnnualDaylightMetrics(Function):
     )
 
     metrics_info = Outputs.file(
-        description='The information for metrics subfolders as a JSON file.',
-        path='metrics/metrics_info.json'
+        description='A config file with metrics subfolders information for '
+        'visualization. This config file is compatible with honeybee-vtk config.',
+        path='metrics/config.json'
     )
 
     daylight_autonomy = Outputs.folder(


### PR DESCRIPTION
The latest update introduced a bug which is resolved in this commit by pointing to the correct output file.