### PR TITLE
fix(grid): Expose sensor grid file on split model folder

### DIFF
--- a/pollination/honeybee_radiance/grid.py
+++ b/pollination/honeybee_radiance/grid.py
@@ -78,6 +78,11 @@ class SplitGridFolder(Function):
         'grids.', path='output_folder/_info.json'
     )
 
+    sensor_grids_file = Outputs.file(
+        description='A JSON file with information about generated sensor grids.',
+        path='output_folder/_info.json'
+    )
+
     dist_info = Outputs.file(
         description='A JSON file with distribution information.',
         path='output_folder/_redist_info.json'


### PR DESCRIPTION
I found that I need this to get around the fact that you can't pass a list from one DAG to another.